### PR TITLE
Remove unnecessary type cast

### DIFF
--- a/src/models/Root.ts
+++ b/src/models/Root.ts
@@ -27,5 +27,5 @@ export function useMst() {
   if (store === null) {
     throw new Error("Store cannot be null, please add a context provider");
   }
-  return store as RootInstance;
+  return store;
 }


### PR DESCRIPTION
The type cast is unnecessary here because TypeScript will narrow down type `RootInstance | null` to `RootInstance` after the `if (store === null) {`
